### PR TITLE
Updated version of GCC

### DIFF
--- a/C++14_os_x.sublime-build
+++ b/C++14_os_x.sublime-build
@@ -1,5 +1,5 @@
 {
-  "cmd" : ["g++-10 $file_name -o $file_base_name && gtimeout 4s ./$file_base_name<inputf.in>outputf.in"], 
+  "cmd" : ["g++-11 $file_name -o $file_base_name && gtimeout 4s ./$file_base_name<inputf.in>outputf.in"], 
   "selector" : "source.c",
   "shell": true,
   "working_dir" : "$file_path"


### PR DESCRIPTION
The version of GCC is now v11 so command g++-10 will not work so use g++-11