### PR TITLE
Upgrade the g++ version

### DIFF
--- a/C++14_os_x.sublime-build
+++ b/C++14_os_x.sublime-build
@@ -1,5 +1,5 @@
 {
-  "cmd" : ["g++-10 $file_name -o $file_base_name && gtimeout 4s ./$file_base_name<inputf.in>outputf.in"], 
+  "cmd" : ["g++-15 $file_name -o $file_base_name && gtimeout 4s ./$file_base_name<inputf.in>outputf.in"], 
   "selector" : "source.c",
   "shell": true,
   "working_dir" : "$file_path"


### PR DESCRIPTION
This pull request updates the Sublime Text build system configuration for C++ development on macOS. The most important change is the upgrade of the GCC compiler version used in the build command.

Build system update:

* [`C++14_os_x.sublime-build`](diffhunk://#diff-f30535cca8700dc474057430105c3d109155e957f70bef974f91dc0475dc88f3L2-R2): Updated the GCC compiler version from `g++-10` to `g++-15` in the build command to ensure compatibility with newer C++ standards and features.